### PR TITLE
Bug fix: checks parent USL directory to see if forecast exists

### DIFF
--- a/thetae/data_parsers/usl.py
+++ b/thetae/data_parsers/usl.py
@@ -53,9 +53,7 @@ def check_if_usl_forecast_exists(config, stid, run, forecast_date):
     page = response.read().decode('utf-8', 'ignore')
 
     # Look for string of USL run time in the home menu for this station ID (equal to -1 if not found)
-    if page.find(run_strtime) != -1:
-        return
-    else:
+    if page.find(run_strtime) == -1:
         if config['debug'] > 9:
             print("usl: forecast for %s at run time %s hasn't run yet" % (stid, run_date))
         raise URLError("- usl: no correct date/time choice")


### PR DESCRIPTION
I noticed when fixing the old theta-e that the URL-based USL parser will sometimes grab the wrong forecast--if the URL doesn't exist it defaults to the latest forecast. This seemed to be happening in the new theta-e also since the 22Z USL is already there even though it doesn't exist yet (it is falsely pulling 12Z USL). This bug fix should resolve that. Implemented but not tested for historical. 