### PR TITLE
replace GEFS MOS with NBS MOS

### DIFF
--- a/theta-e.conf
+++ b/theta-e.conf
@@ -86,10 +86,10 @@ version = 0.0.2
         run_time = 18Z
         bufr_name = gfs
 
-    [[GEFS MOS]]
-        driver = thetae.data_parsers.gefs_mos
-        historical = False
-        ensemble_file = gefs_mos.csv
+    [[NBS MOS]]
+        driver = thetae.data_parsers.mos
+        historical = True
+        mos_model = NBS
         color = '#0099ff'
 
     [[NAM MOS]]


### PR DESCRIPTION
Simple swap in the .conf file!

I left the gefs_mos.py data parser but that could be deleted. 